### PR TITLE
Added package.json for installation in cordova 7.0.1 environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "cordova-plugin-adv-tts",
+  "version": "1.0.0",
+  "description": "Cordova Plugin Adv TTS",
+  "cordova": {
+    "id": "cordova-plugin-adv-tts",
+    "platforms": [
+      "android",
+      "ios"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GruppoMeta/cordova-plugin-adv-tts.git"
+  },
+  "keywords": [
+    "cordova",
+    "device",
+    "ecosystem:cordova",
+    "cordova-android",
+    "cordova-ios"
+  ],
+  "author": "GruppoMeta",
+  "license": "Apache 2.0",
+  "bugs": {
+    "url": "https://github.com/GruppoMeta/cordova-plugin-adv-tts/issues"
+  },
+  "homepage": "https://github.com/GruppoMeta/cordova-plugin-adv-tts#readme"
+}


### PR DESCRIPTION
A valid package.json is required for plugins in cordova 7.0.1 